### PR TITLE
adding the ability for hammer-cli-sam commands to remove options

### DIFF
--- a/lib/hammer_cli_sam.rb
+++ b/lib/hammer_cli_sam.rb
@@ -35,6 +35,9 @@ module HammerCLISAM
     HammerCLI::MainCommand.remove_subcommand(cmd)
   end
 
+  require 'hammer_cli_sam/exclude_mixin'
+
+  require 'hammer_cli_sam/activation_key'
   require 'hammer_cli_sam/content_host'
   require 'hammer_cli_sam/location'
   require 'hammer_cli_sam/organization'

--- a/lib/hammer_cli_sam/activation_key.rb
+++ b/lib/hammer_cli_sam/activation_key.rb
@@ -1,0 +1,45 @@
+module HammerCLISAM
+
+  HammerCLI::MainCommand.find_subcommand('activation-key').subcommand_class
+
+  module ActivationKeyCommand
+
+    class CreateCommand < HammerCLIKatello::ActivationKeyCommand::CreateCommand
+      include HammerCLISAM::ExcludeOptions
+
+      exclude_options(:environment, :content_view)
+    end
+
+    class ListCommand < HammerCLIKatello::ActivationKeyCommand::ListCommand
+      include HammerCLISAM::ExcludeOptions
+
+      exclude_options(:environment, :content_view)
+    end
+
+    class UpdateCommand < HammerCLIKatello::ActivationKeyCommand::UpdateCommand
+      include HammerCLISAM::ExcludeOptions
+
+      exclude_options(:environment, :content_view)
+    end
+
+  end
+
+  HammerCLIKatello::ActivationKeyCommand.subcommand!(
+    HammerCLIKatello::ActivationKeyCommand::CreateCommand.command_name,
+    HammerCLIKatello::ActivationKeyCommand::CreateCommand.desc,
+    HammerCLISAM::ActivationKeyCommand::CreateCommand
+  )
+
+  HammerCLIKatello::ActivationKeyCommand.subcommand!(
+    HammerCLIKatello::ActivationKeyCommand::ListCommand.command_name,
+    HammerCLIKatello::ActivationKeyCommand::ListCommand.desc,
+    HammerCLISAM::ActivationKeyCommand::ListCommand
+  )
+
+  HammerCLIKatello::ActivationKeyCommand.subcommand!(
+    HammerCLIKatello::ActivationKeyCommand::UpdateCommand.command_name,
+    HammerCLIKatello::ActivationKeyCommand::UpdateCommand.desc,
+    HammerCLISAM::ActivationKeyCommand::UpdateCommand
+  )
+
+end

--- a/lib/hammer_cli_sam/content_host.rb
+++ b/lib/hammer_cli_sam/content_host.rb
@@ -11,4 +11,32 @@ module HammerCLISAM
     HammerCLI::MainCommand.find_subcommand('content-host').subcommand_class.remove_subcommand(cmd)
   end
 
+  module ContentHostCommand
+
+    class ListCommand < HammerCLIKatello::ContentHostCommand::ListCommand
+      include HammerCLISAM::ExcludeOptions
+
+      exclude_options(:environment)
+    end
+
+    class UpdateCommand < HammerCLIKatello::ContentHostCommand::UpdateCommand
+      include HammerCLISAM::ExcludeOptions
+
+      exclude_options(:environment, :content_view)
+    end
+
+  end
+
+  HammerCLIKatello::ContentHostCommand.subcommand!(
+    HammerCLIKatello::ContentHostCommand::ListCommand.command_name,
+    HammerCLIKatello::ContentHostCommand::ListCommand.desc,
+    HammerCLISAM::ContentHostCommand::ListCommand
+  )
+
+  HammerCLIKatello::ContentHostCommand.subcommand!(
+    HammerCLIKatello::ContentHostCommand::UpdateCommand.command_name,
+    HammerCLIKatello::ContentHostCommand::UpdateCommand.desc,
+    HammerCLISAM::ContentHostCommand::UpdateCommand
+  )
+
 end

--- a/lib/hammer_cli_sam/exclude_mixin.rb
+++ b/lib/hammer_cli_sam/exclude_mixin.rb
@@ -1,0 +1,37 @@
+module HammerCLISAM
+
+  module ExcludeOptions
+
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+
+      # when #exclude_options is called on a command class,
+      # we take those options and generate a #recognised_options
+      # method overriding the parent's #recognised_options to
+      # pull out the options we don't want.
+      #
+      # it probably seems odd that we're calling #instance_eval here
+      # if this is to be modifying a class. Since we're in the
+      # ClassMethods module while will be applied to the class,
+      # in the current scope, self *is* the class, so our current
+      # instance *is* the class definition.
+      def exclude_options(*options)
+        instance_eval <<-eoruby
+          def recognised_options
+            super.reject! do |opt|
+              #{options.map { |opt| /#{opt.to_s}/ }.inspect}.reduce(false) do |reduced, regex|
+                reduced || (opt.attribute_name =~ regex)
+              end
+            end
+          end
+        eoruby
+      end
+
+    end
+
+  end
+
+end

--- a/lib/hammer_cli_sam/organization.rb
+++ b/lib/hammer_cli_sam/organization.rb
@@ -23,4 +23,48 @@ module HammerCLISAM
     HammerCLI::MainCommand.find_subcommand('organization').subcommand_class.remove_subcommand(cmd)
   end
 
+  module Organization
+
+    class CreateCommand < HammerCLIKatello::Organization::CreateCommand
+      include HammerCLISAM::ExcludeOptions
+
+      exclude_options(:compute_resource,
+                      :config_template,
+                      :domain,
+                      :hostgroup,
+                      :environment,
+                      :media,
+                      :realm,
+                      :smart_proxy,
+                      :subnet)
+    end
+
+    class UpdateCommand < HammerCLIKatello::Organization::UpdateCommand
+      include HammerCLISAM::ExcludeOptions
+
+      exclude_options(:compute_resource,
+                      :config_template,
+                      :domain,
+                      :hostgroup,
+                      :environment,
+                      :media,
+                      :realm,
+                      :smart_proxy,
+                      :subnet)
+    end
+
+  end
+
+  HammerCLIKatello::Organization.subcommand!(
+    HammerCLIKatello::Organization::CreateCommand.command_name,
+    HammerCLIKatello::Organization::CreateCommand.desc,
+    HammerCLISAM::Organization::CreateCommand
+  )
+
+  HammerCLIKatello::Organization.subcommand!(
+    HammerCLIKatello::Organization::UpdateCommand.command_name,
+    HammerCLIKatello::Organization::UpdateCommand.desc,
+    HammerCLISAM::Organization::UpdateCommand
+  )
+
 end

--- a/lib/hammer_cli_sam/product.rb
+++ b/lib/hammer_cli_sam/product.rb
@@ -10,4 +10,32 @@ module HammerCLISAM
     HammerCLI::MainCommand.find_subcommand('product').subcommand_class.remove_subcommand(cmd)
   end
 
+  module Product
+
+    class RemoveSyncPlanCommand < HammerCLIKatello::Product::RemoveSyncPlanCommand
+      include HammerCLISAM::ExcludeOptions
+
+      exclude_options(:gpg_key)
+    end
+
+    class SetSyncPlanCommand < HammerCLIKatello::Product::SetSyncPlanCommand
+      include HammerCLISAM::ExcludeOptions
+
+      exclude_options(:gpg_key)
+    end
+
+  end
+
+  HammerCLIKatello::Product.subcommand!(
+    HammerCLIKatello::Product::RemoveSyncPlanCommand.command_name,
+    HammerCLIKatello::Product::RemoveSyncPlanCommand.desc,
+    HammerCLISAM::Product::RemoveSyncPlanCommand
+  )
+
+  HammerCLIKatello::Product.subcommand!(
+    HammerCLIKatello::Product::SetSyncPlanCommand.command_name,
+    HammerCLIKatello::Product::SetSyncPlanCommand.desc,
+    HammerCLISAM::Product::SetSyncPlanCommand
+  )
+
 end

--- a/lib/hammer_cli_sam/repository.rb
+++ b/lib/hammer_cli_sam/repository.rb
@@ -11,4 +11,22 @@ module HammerCLISAM
     HammerCLI::MainCommand.find_subcommand('repository').subcommand_class.remove_subcommand(cmd)
   end
 
+  module Repository
+
+    class ListCommand < HammerCLIKatello::Repository::ListCommand
+      include HammerCLISAM::ExcludeOptions
+
+      exclude_options(:content_view,
+                      :library,
+                      :environment)
+    end
+
+  end
+
+  HammerCLIKatello::Repository.subcommand!(
+    HammerCLIKatello::Repository::ListCommand.command_name,
+    HammerCLIKatello::Repository::ListCommand.desc,
+    HammerCLISAM::Repository::ListCommand
+  )
+
 end

--- a/lib/hammer_cli_sam/version.rb
+++ b/lib/hammer_cli_sam/version.rb
@@ -1,5 +1,7 @@
 module HammerCLISAM
+
   def self.version
     @version ||= Gem::Version.new('0.0.1')
   end
+
 end


### PR DESCRIPTION
- [x] refactor

in any of the command classes:
1. `include HammerCLISAM::ExcludeOptions`
2. `exclude_options(:opt1, :opt2, ... )` where the :opt symbols are
substrings that are looked for in the existing options.
