### PR TITLE
refs # 8580 - updating tito.props

### DIFF
--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -1,6 +1,6 @@
-[globalconfig]
-default_builder = tito.builder.GemBuilder
-default_tagger = tito.tagger.ReleaseTagger
+[buildconfig]
+builder = tito.builder.GemBuilder
+tagger = tito.tagger.ReleaseTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
 


### PR DESCRIPTION
addressing

```
WARNING: Please rename [globalconfig] to [buildconfig] in tito.props
WARNING: please rename 'default_builder' to 'builder' in tito.props
WARNING: please rename 'default_tagger' to 'tagger' in tito.props
```
