### PR TITLE
refs #8580 - allowing for license and readme

### DIFF
--- a/rubygem-hammer_cli_sam.spec
+++ b/rubygem-hammer_cli_sam.spec
@@ -57,7 +57,7 @@ cp -pa .%{gem_dir}/* \
 
 %files
 %dir %{geminstdir}
-%{geminstdir}/lib
+%{geminstdir}/
 %config(noreplace) %{_sysconfdir}/%{confdir}/cli.modules.d/sam.yml
 %exclude %{gem_dir}/cache/%{gemname}-%{version}.gem
 %{gem_dir}/specifications/%{gemname}-%{version}.gemspec


### PR DESCRIPTION
addressing:

```
RPM build errors:
error: Installed (but unpackaged) file(s) found:
   /usr/lib/ruby/gems/1.8/gems/hammer_cli_sam-0.0.1/LICENSE
   /usr/lib/ruby/gems/1.8/gems/hammer_cli_sam-0.0.1/README.md
    Installed (but unpackaged) file(s) found:
   /usr/lib/ruby/gems/1.8/gems/hammer_cli_sam-0.0.1/LICENSE
   /usr/lib/ruby/gems/1.8/gems/hammer_cli_sam-0.0.1/README.md
Child return code was: 1
```
